### PR TITLE
Added `unit_of_measurement`

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,10 +111,12 @@ sensor:
   - platform: mqtt
     state_topic: "readings/12345678/meter_reading"
     name: "Power Meter"
+    unit_of_measurement: kWh
 
   - platform: mqtt
     state_topic: "readings/12345678/meter_rate"
     name: "Power Meter Avg Usage 5 mins"
+    unit_of_measurement: kWh
   ```
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ sensor:
   - platform: mqtt
     state_topic: "readings/12345678/meter_rate"
     name: "Power Meter Avg Usage 5 mins"
-    unit_of_measurement: kWh
+    unit_of_measurement: Wh
   ```
 
 ## Testing


### PR DESCRIPTION
Added `unit_of_measurement` to Home Assistant example. This will allow graphs to be generated from the sensor data